### PR TITLE
CBA Settings - HC Loadout Transfer disabled

### DIFF
--- a/CVO_co@30_Hearts_and_Minds.SefrouRamal/cba_settings.sqf
+++ b/CVO_co@30_Hearts_and_Minds.SefrouRamal/cba_settings.sqf
@@ -159,7 +159,7 @@ force acex_headless_delay = 60;
 force acex_headless_enabled = true;
 force acex_headless_endMission = 2;
 force acex_headless_log = false;
-force acex_headless_transferLoadout = 1;
+force acex_headless_transferLoadout = 0;
 
 // ACE Hearing
 force ace_hearing_autoAddEarplugsToUnits = 1;


### PR DESCRIPTION
Some of the UNA Crimescene investigators lost their custom equipment. i assume it might be because of this setting